### PR TITLE
Updated to latest okhttpd client

### DIFF
--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>
-      <version>2.0.0</version>
+      <version>2.3.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The newer client drops SSL 3.0 due to the POODLE attack vulnerability.
https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-220
and gets rid of some of the older RC4 ciphers.
https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-230

