### PR TITLE
Update okhttp to version 3, update other dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 *~
 target/

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.0</version>
+      <version>20.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-client</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
 
   <name>Duo Security API client</name>
@@ -16,25 +16,25 @@
   <dependencies>
     <dependency>
       <groupId>org.json</groupId>
-      <artifactId>org.json</artifactId>
-      <version>chargebee-1.0</version>
+      <artifactId>json</artifactId>
+      <version>20170516</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>2.3.0</version>
+      <version>3.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>13.0.1</version>
+      <version>23.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -1,11 +1,11 @@
 package com.duosecurity.client;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -97,14 +97,18 @@ public class Http {
           .build();
 
       // Set up client.
-      OkHttpClient httpclient = new OkHttpClient();
+      OkHttpClient.Builder httpbuilder = new OkHttpClient.Builder();
+      
+      httpbuilder.connectTimeout(timeout, TimeUnit.SECONDS);
+      httpbuilder.writeTimeout(timeout, TimeUnit.SECONDS);
+      httpbuilder.readTimeout(timeout, TimeUnit.SECONDS);
+                   
       if (proxy != null) {
-        httpclient.setProxy(proxy);
+        httpbuilder.proxy(proxy);
       }
 
-      httpclient.setConnectTimeout(timeout, TimeUnit.SECONDS);
-      httpclient.setWriteTimeout(timeout, TimeUnit.SECONDS);
-      httpclient.setReadTimeout(timeout, TimeUnit.SECONDS);
+      OkHttpClient httpclient = httpbuilder.build();
+
       // finish and execute request
       builder.headers(headers.build());
       return httpclient.newCall(builder.build())

--- a/duo-example-admin/pom.xml
+++ b/duo-example-admin/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-example-admin</artifactId>
-  <version>0.2</version>
+  <version>0.3</version>
   <packaging>jar</packaging>
 
   <name>Duo Admin API Example client</name>
@@ -16,14 +16,14 @@
   <parent>
     <groupId>com.duosecurity</groupId>
     <artifactId>duo-client-all</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.duosecurity</groupId>
       <artifactId>duo-client</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/duo-example-verify/pom.xml
+++ b/duo-example-verify/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-example-verify</artifactId>
-  <version>0.2</version>
+  <version>0.3</version>
   <packaging>jar</packaging>
 
   <name>Duo Verify Example client</name>
@@ -16,14 +16,14 @@
   <parent>
     <groupId>com.duosecurity</groupId>
     <artifactId>duo-client-all</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.duosecurity</groupId>
       <artifactId>duo-client</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-client-all</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <packaging>pom</packaging>
 
   <name>Duo Security API client and examples</name>


### PR DESCRIPTION
I have successfully tested this with the duo-example-admin project locally against our QA instance of Duo. okhttp updated to version 3.0 in January 2016 with some breaking changes. There have been a number of updates since then and the latest is now 3.9.0.

**In this PR:**
- Adds .DS_Store to gitignore for macOS
- Update okhttp from 2.3.0 to 3.9.0
- Update json package from a 2012 chargebee patched version to the latest release, from 2017-05-16
- Update junit from 4.10 to 4.12
- Update guava from 13.0.1 to 20.0 (latest is 23.0 but requires Java 8)
- Update duo-example-admin and duo-example-verify to use 0.3.0
- Bump all library versions to 0.3.0

I am happy to further discuss or test these changes, or to roll back other non-okhttp dependency updates if needed. The main update here is okhttp -> okhttp3.

UPDATE: The TravisCI build failure came from the guava library version. I downgraded it to 20, which is the latest version that supports Java 7.