### PR TITLE
Add executeJSONRequest to allow accessing full response for pagination

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -54,6 +54,11 @@ public class Http {
     }
 
     public Object executeRequest() throws Exception {
+        JSONObject result = (JSONObject)executeJSONRequest();
+        return result.get("response");
+    }
+
+    public Object executeJSONRequest() throws Exception {
         JSONObject result = new JSONObject(executeRequestRaw());
         if (! result.getString("stat").equals("OK")) {
             throw new Exception("Duo error code ("
@@ -61,8 +66,10 @@ public class Http {
                                 + "): "
                                 + result.getString("message"));
         }
-        return result.get("response");
+        return result;
     }
+
+
 
     public String executeRequestRaw() throws Exception {
         Response response = executeHttpRequest();


### PR DESCRIPTION
When paginating requests, consumers need access to the request metadata
returned in the JSON response. This adds a method that returns
the full JSON object, so the metadata can be accessed.