### PR TITLE
Add automatic request retry/backoff when rate limited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 target/
+.idea/

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-client</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
 
   <name>Duo Security API client</name>

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -37,6 +37,13 @@
       <version>13.0.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -18,10 +18,11 @@ import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 
 public class Http {
-    public final static int MAX_REQUEST_ATTEMPTS = 8;
+    public final static int MAX_REQUEST_ATTEMPTS = 7;
     public final static int BACKOFF_FACTOR = 2;
     public final static int MAX_BACKOFF_MS = 32000;
     public final static int DEFAULT_TIMEOUT_SECS = 60;
+    private final static int RATE_LIMIT_ERROR_CODE = 429;
 
     private String method;
     private String host;
@@ -108,7 +109,7 @@ public class Http {
     private Response executeRequest(Request request) throws Exception {
       Response response = httpClient.newCall(request).execute();
       int attempts = 1;
-      while (attempts < MAX_REQUEST_ATTEMPTS && response.code() == 429) {
+      while (attempts < MAX_REQUEST_ATTEMPTS && response.code() == RATE_LIMIT_ERROR_CODE) {
         sleep(getBackoffMs(attempts));
         response = httpClient.newCall(request).execute();
         attempts++;

--- a/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
@@ -42,7 +42,6 @@ public class HttpRateLimitRetryTest {
         httpClientField.setAccessible(true);
         httpClientField.set(http, httpClient);
 
-
         Mockito.when(random.nextInt(1000)).thenReturn(RANDOM_INT);
         Mockito.doNothing().when(http).sleep(Mockito.any(Long.class));
     }
@@ -125,7 +124,7 @@ public class HttpRateLimitRetryTest {
         assertEquals(4000L + RANDOM_INT, (long) sleepTimes.get(2));
         assertEquals(8000L + RANDOM_INT, (long) sleepTimes.get(3));
         assertEquals(16000L + RANDOM_INT, (long) sleepTimes.get(4));
-        assertEquals(32000L, (long) sleepTimes.get(5));
-        assertEquals(32000L, (long) sleepTimes.get(6));
+        assertEquals(32000L + RANDOM_INT, (long) sleepTimes.get(5));
+        assertEquals(32000L + RANDOM_INT, (long) sleepTimes.get(6));
     }
 }

--- a/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
@@ -1,0 +1,131 @@
+package com.duosecurity.client;
+
+import com.squareup.okhttp.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpRateLimitRetryTest {
+    @Mock
+    private OkHttpClient httpClient;
+    @Mock
+    private Random random;
+
+    private Http http;
+
+    private final int RANDOM_INT = 234;
+
+    @Before
+    public void before() throws Exception {
+        http = new Http("GET", "example.test", "/foo/bar");
+        http = Mockito.spy(http);
+
+        Field randomField = Http.class.getDeclaredField("random");
+        randomField.setAccessible(true);
+        randomField.set(http, random);
+
+        Field httpClientField = Http.class.getDeclaredField("httpClient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(http, httpClient);
+
+
+        Mockito.when(random.nextInt(1000)).thenReturn(RANDOM_INT);
+        Mockito.doNothing().when(http).sleep(Mockito.any(Long.class));
+    }
+
+    @Test
+    public void testSingleRateLimitRetry() throws Exception {
+        final List<Response> responses = new ArrayList<Response>();
+        final List<Call> calls = new ArrayList<Call>();
+
+        Mockito.when(httpClient.newCall(Mockito.any(Request.class))).thenAnswer(new Answer<Call>() {
+            @Override
+            public Call answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Call call = Mockito.mock(Call.class);
+                calls.add(call);
+
+                Response resp = new Response.Builder()
+                        .protocol(Protocol.HTTP_2)
+                        .code(responses.isEmpty() ? 429 : 200) // Fail on first req, succeed after
+                        .request((Request) invocationOnMock.getArguments()[0])
+                        .build();
+                responses.add(resp);
+                Mockito.when(call.execute()).thenReturn(resp);
+
+                return call;
+            }
+        });
+
+        Response actualRes = http.executeHttpRequest();
+        assertEquals(2, responses.size());
+        assertEquals(2, calls.size());
+        assertEquals(200, actualRes.code());
+
+        // Verify the calls to sleep on failures
+        ArgumentCaptor<Long> sleepCapture = ArgumentCaptor.forClass(Long.class);
+        Mockito.verify(http).sleep(sleepCapture.capture());
+        List<Long> sleepTimes = sleepCapture.getAllValues();
+        assertEquals(1000L + RANDOM_INT, (long) sleepTimes.get(0));
+    }
+
+    @Test
+    public void testRepeatRetryAfterRateLimit() throws Exception {
+        final List<Response> responses = new ArrayList<Response>();
+        final List<Call> calls = new ArrayList<Call>();
+
+        Mockito.when(httpClient.newCall(Mockito.any(Request.class))).thenAnswer(new Answer<Call>() {
+            @Override
+            public Call answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Call call = Mockito.mock(Call.class);
+                calls.add(call);
+
+                Response resp = new Response.Builder()
+                        .protocol(Protocol.HTTP_2)
+                        .code(429)
+                        .request((Request) invocationOnMock.getArguments()[0])
+                        .build();
+                responses.add(resp);
+                Mockito.when(call.execute()).thenReturn(resp);
+
+                return call;
+            }
+        });
+
+        Response actualRes = http.executeHttpRequest();
+        assertEquals(Http.MAX_REQUEST_ATTEMPTS, responses.size());
+        assertEquals(Http.MAX_REQUEST_ATTEMPTS, calls.size());
+        assertEquals(responses.get(responses.size() - 1), actualRes);
+
+        // Verify execution of the new calls
+        for (Call call: calls) {
+            Mockito.verify(call).execute();
+        }
+
+        // Verify the calls to sleep on failures
+        ArgumentCaptor<Long> sleepCapture = ArgumentCaptor.forClass(Long.class);
+        Mockito.verify(http, Mockito.times(Http.MAX_REQUEST_ATTEMPTS - 1))
+                .sleep(sleepCapture.capture());
+        List<Long> sleepTimes = sleepCapture.getAllValues();
+        assertEquals(1000L + RANDOM_INT, (long) sleepTimes.get(0));
+        assertEquals(2000L + RANDOM_INT, (long) sleepTimes.get(1));
+        assertEquals(4000L + RANDOM_INT, (long) sleepTimes.get(2));
+        assertEquals(8000L + RANDOM_INT, (long) sleepTimes.get(3));
+        assertEquals(16000L + RANDOM_INT, (long) sleepTimes.get(4));
+        assertEquals(32000L, (long) sleepTimes.get(5));
+        assertEquals(32000L, (long) sleepTimes.get(6));
+    }
+}

--- a/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
@@ -125,6 +125,5 @@ public class HttpRateLimitRetryTest {
         assertEquals(8000L + RANDOM_INT, (long) sleepTimes.get(3));
         assertEquals(16000L + RANDOM_INT, (long) sleepTimes.get(4));
         assertEquals(32000L + RANDOM_INT, (long) sleepTimes.get(5));
-        assertEquals(32000L + RANDOM_INT, (long) sleepTimes.get(6));
     }
 }

--- a/duo-example-admin/pom.xml
+++ b/duo-example-admin/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-example-admin</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
 
   <name>Duo Admin API Example client</name>
@@ -16,14 +16,14 @@
   <parent>
     <groupId>com.duosecurity</groupId>
     <artifactId>duo-client-all</artifactId>
-    <version>0.2.2</version>
+    <version>0.3.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.duosecurity</groupId>
       <artifactId>duo-client</artifactId>
-      <version>0.2.2</version>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.duosecurity</groupId>
   <artifactId>duo-client-all</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
   <packaging>pom</packaging>
 
   <name>Duo Security API client and examples</name>


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.