### PR TITLE
Drop Java 6 support.  Add Java 11 to CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [7, 8]
+        java: [8, 11]
 
     steps:
       - uses: actions/checkout@v2

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -75,8 +75,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <debug>true</debug>
         </configuration>
       </plugin>


### PR DESCRIPTION
We don't need Java 6 support anymore