### PR TITLE
Allow hostname verifier and socket factory for http component

### DIFF
--- a/duo-client/duo-client.iml
+++ b/duo-client/duo-client.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
+</module>

--- a/duo-client/duo-client.iml
+++ b/duo-client/duo-client.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
-</module>

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -20,7 +20,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
+import okhttp3.internal.tls.OkHostnameVerifier;
 import org.json.JSONObject;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
 
 public class Http {
   public static final int BACKOFF_FACTOR = 2;
@@ -51,15 +56,21 @@ public class Http {
     this(inMethod, inHost, inUri, DEFAULT_TIMEOUT_SECS);
   }
 
+  public Http(String inMethod, String inHost, String inUri, int timeout) {
+      this(inMethod, inHost, inUri, timeout, OkHostnameVerifier.INSTANCE, SocketFactory.getDefault());
+  }
   /**
    * Http constructor.
    *
-   * @param inMethod    The method for the http request
-   * @param inHost      The api host provided by Duo and found in the Duo admin panel
-   * @param inUri       The endpoint for the request
-   * @param timeout     The timeout for the http request
+   * @param inMethod         The method for the http request
+   * @param inHost           The api host provided by Duo and found in the Duo admin panel
+   * @param inUri            The endpoint for the request
+   * @param timeout          The timeout for the http request
+   * @param hostnameVerifier the hostname verifier
+   * @param socketFactory    the socket factory
    */
-  public Http(String inMethod, String inHost, String inUri, int timeout) {
+  public Http(String inMethod, String inHost, String inUri, int timeout,
+              HostnameVerifier hostnameVerifier, SocketFactory socketFactory) {
     method = inMethod.toUpperCase();
     host = inHost;
     uri = inUri;
@@ -73,7 +84,9 @@ public class Http {
                      .connectTimeout(timeout, TimeUnit.SECONDS)
                      .writeTimeout(timeout, TimeUnit.SECONDS)
                      .readTimeout(timeout, TimeUnit.SECONDS)
-                      .build();
+                     .socketFactory(socketFactory)
+                     .hostnameVerifier(hostnameVerifier)
+                     .build();
   }
 
   /**

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.internal.tls.OkHostnameVerifier;
 import org.json.JSONObject;
 
 import javax.net.SocketFactory;
@@ -57,7 +56,7 @@ public class Http {
   }
 
   public Http(String inMethod, String inHost, String inUri, int timeout) {
-      this(inMethod, inHost, inUri, timeout, OkHostnameVerifier.INSTANCE, SocketFactory.getDefault());
+      this(inMethod, inHost, inUri, timeout, null, null);
   }
   /**
    * Http constructor.
@@ -66,8 +65,8 @@ public class Http {
    * @param inHost           The api host provided by Duo and found in the Duo admin panel
    * @param inUri            The endpoint for the request
    * @param timeout          The timeout for the http request
-   * @param hostnameVerifier the hostname verifier
-   * @param socketFactory    the socket factory
+   * @param hostnameVerifier the hostname verifier; may be null
+   * @param socketFactory    the socket factory; may be null
    */
   public Http(String inMethod, String inHost, String inUri, int timeout,
               HostnameVerifier hostnameVerifier, SocketFactory socketFactory) {
@@ -80,13 +79,18 @@ public class Http {
     headers.add("Host", host);
     headers.add("user-agent", UserAgentString);
 
-    httpClient = new OkHttpClient.Builder()
-                     .connectTimeout(timeout, TimeUnit.SECONDS)
-                     .writeTimeout(timeout, TimeUnit.SECONDS)
-                     .readTimeout(timeout, TimeUnit.SECONDS)
-                     .socketFactory(socketFactory)
-                     .hostnameVerifier(hostnameVerifier)
-                     .build();
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        .connectTimeout(timeout, TimeUnit.SECONDS)
+        .writeTimeout(timeout, TimeUnit.SECONDS)
+        .readTimeout(timeout, TimeUnit.SECONDS);
+
+    if (hostnameVerifier != null) {
+      builder.hostnameVerifier(hostnameVerifier);
+    }
+    if (socketFactory != null) {
+      builder.socketFactory(socketFactory);
+    }
+    httpClient = builder.build();
   }
 
   /**


### PR DESCRIPTION
- Allows one to specify a hostname verifier and socket factory when creating instances of Http.
- Overloads the constructor to keep backward compatibility. 