### PR TITLE
Remove setSigningAlgorithm() from HTTP client - always use SHA512

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -25,13 +25,12 @@ public class Http {
   public static final int DEFAULT_TIMEOUT_SECS = 60;
   private static final int RATE_LIMIT_ERROR_CODE = 429;
 
-  public static final String HmacSHA512 = "HmacSHA512";
   public static final String UserAgentString = "Duo API Java/0.5.1-SNAPSHOT";
 
   private final String method;
   private final String host;
   private final String uri;
-  private String signingAlgorithm;
+  private final String signingAlgorithm = "HmacSHA512";
   private Headers.Builder headers;
   Map<String, String> params = new HashMap<String, String>();
   private Random random = new Random();
@@ -85,7 +84,6 @@ public class Http {
     method = inMethod.toUpperCase();
     host = inHost;
     uri = inUri;
-    signingAlgorithm = HmacSHA512;
 
     headers = new Headers.Builder();
     headers.add("Host", host);
@@ -256,21 +254,6 @@ public class Http {
   public void useCustomCertificates(String[] customCaCerts) {
     CertificatePinner pinner = Util.createPinner(host, customCaCerts);
     httpClient = httpClient.newBuilder().certificatePinner(pinner).build();
-  }
-
-  /**
-   * Set Signing Algorithm.
-   *
-   * @param algorithm   The algorith used for signing
-   *
-   * @throws NoSuchAlgorithmException For algorithms that are not HmacSHA512
-   */
-  public void setSigningAlgorithm(String algorithm)
-      throws NoSuchAlgorithmException {
-    if (algorithm != HmacSHA512) {
-      throw new NoSuchAlgorithmException(algorithm);
-    }
-    signingAlgorithm = algorithm;
   }
 
   protected String canonRequest(String date, int sigVersion)

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -25,7 +25,6 @@ public class Http {
   public static final int DEFAULT_TIMEOUT_SECS = 60;
   private static final int RATE_LIMIT_ERROR_CODE = 429;
 
-  public static final String HmacSHA1 = "HmacSHA1";
   public static final String HmacSHA512 = "HmacSHA512";
   public static final String UserAgentString = "Duo API Java/0.5.1-SNAPSHOT";
 
@@ -86,7 +85,7 @@ public class Http {
     method = inMethod.toUpperCase();
     host = inHost;
     uri = inUri;
-    signingAlgorithm = "HmacSHA1";
+    signingAlgorithm = HmacSHA512;
 
     headers = new Headers.Builder();
     headers.add("Host", host);
@@ -264,11 +263,11 @@ public class Http {
    *
    * @param algorithm   The algorith used for signing
    *
-   * @throws NoSuchAlgorithmException For algorithms that are not HmacSHA1 or HmacSHA512
+   * @throws NoSuchAlgorithmException For algorithms that are not HmacSHA512
    */
   public void setSigningAlgorithm(String algorithm)
       throws NoSuchAlgorithmException {
-    if (algorithm != HmacSHA1 && algorithm != HmacSHA512) {
+    if (algorithm != HmacSHA512) {
       throw new NoSuchAlgorithmException(algorithm);
     }
     signingAlgorithm = algorithm;

--- a/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
@@ -9,15 +9,10 @@ public class HttpSignHMACTest {
         return new Http.HttpBuilder("get", "API.test", "/v1/tEst").build();
     }
 
-    @Test
-    public void testSignHMACSHA1() {
+    @Test(expected=NoSuchAlgorithmException.class)
+    public void testSetHMACSHA1ThrowsNoSuchAlgorithmException() throws NoSuchAlgorithmException {
         Http h = makeHttp();
-        String key = "gtdfxv9YgVBYcF6dl2Eq17KUQJN2PLM2ODVTkvoT";
-        String msg = "Fri, 07 Dec 2012 17:18:00 -0000\nPOST\nfoo.bar52.com\n/Foo/BaR2/qux\n%E4%9A%9A%E2%A1%BB%E3%97%90%E8%BB%B3%E6%9C%A7%E5%80%AA%E0%A0%90%ED%82%91%C3%88%EC%85%B0=%E0%BD%85%E1%A9%B6%E3%90%9A%E6%95%8C%EC%88%BF%E9%AC%89%EA%AF%A2%E8%8D%83%E1%AC%A7%E6%83%90&%E7%91%89%E7%B9%8B%EC%B3%BB%E5%A7%BF%EF%B9%9F%E8%8E%B7%EA%B7%8C%E9%80%8C%EC%BF%91%E7%A0%93=%E8%B6%B7%E5%80%A2%E9%8B%93%E4%8B%AF%E2%81%BD%E8%9C%B0%EA%B3%BE%E5%98%97%E0%A5%86%E4%B8%B0&%E7%91%B0%E9%8C%94%E9%80%9C%E9%BA%AE%E4%83%98%E4%88%81%E8%8B%98%E8%B1%B0%E1%B4%B1%EA%81%82=%E1%9F%99%E0%AE%A8%E9%8D%98%EA%AB%9F%EA%90%AA%E4%A2%BE%EF%AE%96%E6%BF%A9%EB%9F%BF%E3%8B%B3&%EC%8B%85%E2%B0%9D%E2%98%A0%E3%98%97%E9%9A%B3F%E8%98%85%E2%83%A8%EA%B0%A1%E5%A4%B4=%EF%AE%A9%E4%86%AA%EB%B6%83%E8%90%8B%E2%98%95%E3%B9%AE%E6%94%AD%EA%A2%B5%ED%95%ABU";
-
-        Assert.assertEquals("failure - HMAC-SHA1",
-                            "f01811cbbf9561623ab45b893096267fd46a5178",
-                            h.signHMAC(key, msg));
+        h.setSigningAlgorithm("HmacSHA1");
     }
 
     @Test

--- a/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
@@ -9,28 +9,14 @@ public class HttpSignHMACTest {
         return new Http.HttpBuilder("get", "API.test", "/v1/tEst").build();
     }
 
-    @Test(expected=NoSuchAlgorithmException.class)
-    public void testSetHMACSHA1ThrowsNoSuchAlgorithmException() throws NoSuchAlgorithmException {
-        Http h = makeHttp();
-        h.setSigningAlgorithm("HmacSHA1");
-    }
-
     @Test
     public void testSignHMACSHA512() throws NoSuchAlgorithmException {
         Http h = makeHttp();
         String key = "gtdfxv9YgVBYcF6dl2Eq17KUQJN2PLM2ODVTkvoT";
         String msg = "Fri, 07 Dec 2012 17:18:00 -0000\nPOST\nfoo.bar52.com\n/Foo/BaR2/qux\n%E4%9A%9A%E2%A1%BB%E3%97%90%E8%BB%B3%E6%9C%A7%E5%80%AA%E0%A0%90%ED%82%91%C3%88%EC%85%B0=%E0%BD%85%E1%A9%B6%E3%90%9A%E6%95%8C%EC%88%BF%E9%AC%89%EA%AF%A2%E8%8D%83%E1%AC%A7%E6%83%90&%E7%91%89%E7%B9%8B%EC%B3%BB%E5%A7%BF%EF%B9%9F%E8%8E%B7%EA%B7%8C%E9%80%8C%EC%BF%91%E7%A0%93=%E8%B6%B7%E5%80%A2%E9%8B%93%E4%8B%AF%E2%81%BD%E8%9C%B0%EA%B3%BE%E5%98%97%E0%A5%86%E4%B8%B0&%E7%91%B0%E9%8C%94%E9%80%9C%E9%BA%AE%E4%83%98%E4%88%81%E8%8B%98%E8%B1%B0%E1%B4%B1%EA%81%82=%E1%9F%99%E0%AE%A8%E9%8D%98%EA%AB%9F%EA%90%AA%E4%A2%BE%EF%AE%96%E6%BF%A9%EB%9F%BF%E3%8B%B3&%EC%8B%85%E2%B0%9D%E2%98%A0%E3%98%97%E9%9A%B3F%E8%98%85%E2%83%A8%EA%B0%A1%E5%A4%B4=%EF%AE%A9%E4%86%AA%EB%B6%83%E8%90%8B%E2%98%95%E3%B9%AE%E6%94%AD%EA%A2%B5%ED%95%ABU";
 
-        h.setSigningAlgorithm(Http.HmacSHA512);
-
         Assert.assertEquals("failure - HMAC-SHA512",
                             "0508065035a03b2a1de2f453e629e791d180329e157f65df6b3e0f08299d4321e1c5c7a7c7ee6b9e5fc80d1fb6fbf3ad5eb7c44dd3b3985a02c37aca53ec3698",
                             h.signHMAC(key, msg));
-    }
-
-    @Test(expected=NoSuchAlgorithmException.class)
-    public void testSetAlgorithmInvalidAlgorithm() throws NoSuchAlgorithmException {
-        Http h = makeHttp();
-        h.setSigningAlgorithm("MD5");
     }
 }


### PR DESCRIPTION
This PR removes the ability to use SHA1 as a signing algorithm for the client. It also removes the ability to specify one altogether since SHA512 was the only other supported algorithm we allowed.