### PR TITLE
Repo clean up

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ with Java.
 ## Tested Against Java Versions:
 * 8
 * 11
+* 17
 
 ## TLS 1.2 and 1.3 Support
 

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.1</version>
+      <version>5.0.0-alpha.11</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>5.0.0-alpha.11</version>
+      <version>4.10.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -183,7 +183,7 @@ public class Http {
         return response;
       }
 
-      sleep(backoffMs + random.nextInt(1000));
+      sleep(backoffMs + nextRandomInt(1000));
       backoffMs *= BACKOFF_FACTOR;
     }
   }
@@ -334,6 +334,10 @@ public class Http {
       headers.add(name, value);
     }
     return Util.join(canonList.toArray(), String.valueOf(Character.MIN_VALUE));
+  }
+
+  public int nextRandomInt(int bound){
+    return random.nextInt(bound);
   }
 
 

--- a/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertEquals;
 public class HttpRateLimitRetryTest {
     @Mock
     private OkHttpClient httpClient;
-    @Mock
-    private Random random;
 
     private Http http;
 
@@ -34,15 +32,11 @@ public class HttpRateLimitRetryTest {
         http = new Http.HttpBuilder("GET", "example.test", "/foo/bar").build();
         http = Mockito.spy(http);
 
-        Field randomField = Http.class.getDeclaredField("random");
-        randomField.setAccessible(true);
-        randomField.set(http, random);
-
         Field httpClientField = Http.class.getDeclaredField("httpClient");
         httpClientField.setAccessible(true);
         httpClientField.set(http, httpClient);
 
-        Mockito.when(random.nextInt(1000)).thenReturn(RANDOM_INT);
+        Mockito.when(http.nextRandomInt(1000)).thenReturn(RANDOM_INT);
         Mockito.doNothing().when(http).sleep(Mockito.any(Long.class));
     }
 

--- a/duo-example-admin/pom.xml
+++ b/duo-example-admin/pom.xml
@@ -63,8 +63,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <debug>true</debug>
         </configuration>
       </plugin>


### PR DESCRIPTION
- Add helper function since java 17 don't allow mock random 
- update okhttp version for known vulnerabilities 
- update example source target allow java 17 builds.

Tested locally with both java 8 and java 17, both pass unit test and able to run admin example