### PR TITLE
implement c5

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -46,7 +46,7 @@ public class Http {
       = new SimpleDateFormat("EEE', 'dd' 'MMM' 'yyyy' 'HH:mm:ss' 'Z", Locale.US);
 
   public static MediaType FORM_ENCODED = MediaType.parse("application/x-www-form-urlencoded");
-  public static MediaType JSON_ENCODED = MediaType.parse("application/json; charset=utf-8");
+  public static MediaType JSON_ENCODED = MediaType.parse("application/json");
 
   private static final String[] DEFAULT_CA_CERTS = {
       //C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
@@ -328,10 +328,8 @@ public class Http {
         canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, ""));
       }
       canon += canonParam;
-      canon += canonBody;
-      if (additionalDuoHeaders != null && !additionalDuoHeaders.isEmpty()){
-        canon += System.lineSeparator() + Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonXDuoHeaders()));
-      }
+      canon += canonBody + System.lineSeparator();
+      canon += Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonXDuoHeaders()));
     }
 
     return canon;

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -268,7 +268,7 @@ public class Http {
     params.put(name, value);
   }
 
-  public void addParam(String name, ArrayList<Object> value) {
+  public void addParam(String name, List<Object> value) {
     params.put(name, value);
   }
 

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -36,7 +36,7 @@ public class Http {
   private final String signingAlgorithm = "HmacSHA512";
   private final String hashingAlgorithm = "SHA-512";
   private Headers.Builder headers;
-  private Map<String, String> params = new TreeMap<String, String>();
+  private SortedMap<String, Object> params = new TreeMap<String, Object>();
   private int sigVersion = 2;
   private Random random = new Random();
   private OkHttpClient httpClient;
@@ -144,7 +144,7 @@ public class Http {
     if (sigVersion == 1 || sigVersion == 2){
       requestBody = RequestBody.create(queryString, FORM_ENCODED);
     } else if (sigVersion == 5){
-      if (method.equals("POST") || method.equals("PUT")){
+      if ("POST".equals(method) || "PUT".equals(method)){
         requestBody = RequestBody.create(jsonBody, JSON_ENCODED);
       } else {
         requestBody = null;
@@ -260,6 +260,19 @@ public class Http {
     params.put(name, value);
   }
 
+  public void addParam(String name, Integer value) {
+    params.put(name, value);
+  }
+
+  public void addParam(String name, JSONObject value) {
+    params.put(name, value);
+  }
+
+  public void addParam(String name, ArrayList<Object> value) {
+    params.put(name, value);
+  }
+
+
   public void addAdditionalDuoHeader(Map<String, String> inAdditionalDuoHeaders){
     additionalDuoHeaders.putAll(inAdditionalDuoHeaders);
   }
@@ -307,9 +320,9 @@ public class Http {
       canon += method.toUpperCase() + System.lineSeparator();
       canon += host.toLowerCase() + System.lineSeparator();
       canon += uri + System.lineSeparator();
-      if (method.equals("POST") || method.equals("PUT")){
+      if ("POST".equals(method) || "PUT".equals(method)){
         canonParam = System.lineSeparator();
-        canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonJSONString()));
+        canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonJSONBody()));
       } else {
         canonParam = canonQueryString() + System.lineSeparator();
         canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, ""));
@@ -335,7 +348,7 @@ public class Http {
           .replace("*", "%2A")
           .replace("%7E", "~");
       String value = URLEncoder
-          .encode(params.get(key), "UTF-8")
+          .encode(params.get(key).toString(), "UTF-8")
           .replace("+", "%20")
           .replace("*", "%2A")
           .replace("%7E", "~");
@@ -348,18 +361,6 @@ public class Http {
   private String canonJSONBody(){
     JSONObject jsonBody = new JSONObject(params);
     return jsonBody.toString();
-  }
-
-  private String canonJSONString(){
-    List<String> jsonBody = new ArrayList<>();
-
-    for (String key: params.keySet()){
-      String name = key;
-      String value = params.get(key);
-      jsonBody.add(name + ":" + value);
-    }
-
-    return Util.join(jsonBody.toArray(), ",");
   }
 
   private String canonXDuoHeaders(){

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -215,7 +215,7 @@ public class Http {
    */
   public void signRequest(String ikey, String skey, int inSigVersion)
       throws UnsupportedEncodingException {
-    int[] availableSigVersion = {1, 2};
+    int[] availableSigVersion = {1, 2, 5};
 
     if (Arrays.stream(availableSigVersion).anyMatch(i -> i == inSigVersion)){
       sigVersion = inSigVersion;
@@ -227,7 +227,7 @@ public class Http {
     String auth = ikey + ":" + sig;
     String header = "Basic " + Base64.encodeBytes(auth.getBytes());
     addHeader("Authorization", header);
-    if (sigVersion == 2) {
+    if (sigVersion == 2 || sigVersion == 5) {
       addHeader("Date", date);
     }
   }

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -6,11 +6,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URLEncoder;
-import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -36,8 +34,9 @@ public class Http {
   private final String host;
   private final String uri;
   private final String signingAlgorithm = "HmacSHA512";
+  private final String hashingAlgorithm = "SHA-512";
   private Headers.Builder headers;
-  Map<String, String> params = new HashMap<String, String>();
+  private Map<String, String> params = new TreeMap<String, String>();
   private int sigVersion = 2;
   private Random random = new Random();
   private OkHttpClient httpClient;
@@ -145,7 +144,7 @@ public class Http {
     if (sigVersion == 1 || sigVersion == 2){
       requestBody = RequestBody.create(queryString, FORM_ENCODED);
     } else if (sigVersion == 5){
-      if (method == "POST" || method == "PUT"){
+      if (method.equals("POST") || method.equals("PUT")){
         requestBody = RequestBody.create(jsonBody, JSON_ENCODED);
       } else {
         requestBody = null;
@@ -289,6 +288,8 @@ public class Http {
   protected String canonRequest(String date, int sigVersion)
       throws UnsupportedEncodingException {
     String canon = "";
+    String canonParam;
+    String canonBody;
     if (sigVersion == 1) {
       canon += method.toUpperCase() + System.lineSeparator();
       canon += host.toLowerCase() + System.lineSeparator();
@@ -301,6 +302,23 @@ public class Http {
       canon += host.toLowerCase() + System.lineSeparator();
       canon += uri + System.lineSeparator();
       canon += canonQueryString();
+    } else if (sigVersion == 5){
+      canon += date + System.lineSeparator();
+      canon += method.toUpperCase() + System.lineSeparator();
+      canon += host.toLowerCase() + System.lineSeparator();
+      canon += uri + System.lineSeparator();
+      if (method.equals("POST") || method.equals("PUT")){
+        canonParam = System.lineSeparator();
+        canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonJSONString()));
+      } else {
+        canonParam = canonQueryString() + System.lineSeparator();
+        canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, ""));
+      }
+      canon += canonParam;
+      canon += canonBody;
+      if (additionalDuoHeaders != null && !additionalDuoHeaders.isEmpty()){
+        canon += System.lineSeparator() + Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonXDuoHeaders()));
+      }
     }
 
     return canon;
@@ -309,15 +327,8 @@ public class Http {
   private String canonQueryString()
       throws UnsupportedEncodingException {
     ArrayList<String> args = new ArrayList<String>();
-    ArrayList<String> keys = new ArrayList<String>();
 
     for (String key : params.keySet()) {
-      keys.add(key);
-    }
-
-    Collections.sort(keys);
-
-    for (String key : keys) {
       String name = URLEncoder
           .encode(key, "UTF-8")
           .replace("+", "%20")
@@ -355,7 +366,7 @@ public class Http {
     List<String> canonList = new ArrayList<>();
     for (String name : additionalDuoHeaders.keySet()){
       String value = additionalDuoHeaders.get(name);
-      canonList.add(name + value);
+      canonList.add(name + Character.MIN_VALUE + value);
       headers.add(name, value);
     }
     return Util.join(canonList.toArray(), String.valueOf(Character.MIN_VALUE));

--- a/duo-client/src/main/java/com/duosecurity/client/Util.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Util.java
@@ -2,7 +2,9 @@ package com.duosecurity.client;
 
 import okhttp3.CertificatePinner;
 
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -85,5 +87,22 @@ public class Util {
                                                     .build();
 
     return pinner;
+  }
+
+  /**
+   * Create hash byte array of message
+   *
+   * @param algorithm   The algorithm used to create the hash
+   * @param message     The text to create the hash
+   * @return a byte array
+   */
+  public static byte[] hash(String algorithm, String message) {
+    try{
+      MessageDigest digest = MessageDigest.getInstance(algorithm);
+      byte[] encodedhash = digest.digest(message.getBytes(StandardCharsets.UTF_8));
+      return encodedhash;
+    }catch(Exception e){
+      return new byte[0];
+    }
   }
 }

--- a/duo-client/src/main/java/com/duosecurity/client/Util.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Util.java
@@ -97,12 +97,14 @@ public class Util {
    * @return a byte array
    */
   public static byte[] hash(String algorithm, String message) {
-    try{
-      MessageDigest digest = MessageDigest.getInstance(algorithm);
-      byte[] encodedhash = digest.digest(message.getBytes(StandardCharsets.UTF_8));
-      return encodedhash;
-    }catch(Exception e){
-      return new byte[0];
-    }
+      MessageDigest digest;
+      try {
+        digest = MessageDigest.getInstance(algorithm);
+        byte[] encodedhash = digest.digest(message.getBytes(StandardCharsets.UTF_8));
+        return encodedhash;
+      } catch (NoSuchAlgorithmException e) {
+        e.printStackTrace();
+        return new byte[0];
+      }
   }
 }

--- a/duo-client/src/main/java/com/duosecurity/client/Util.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Util.java
@@ -103,7 +103,6 @@ public class Util {
         byte[] encodedhash = digest.digest(message.getBytes(StandardCharsets.UTF_8));
         return encodedhash;
       } catch (NoSuchAlgorithmException e) {
-        e.printStackTrace();
         return new byte[0];
       }
   }

--- a/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
@@ -1,0 +1,148 @@
+package com.duosecurity.client;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.duosecurity.client.Http.HttpBuilder;
+import com.google.common.collect.Collections2;
+import org.junit.Test;
+import org.junit.Assert;
+
+public class HttpCanonV5RequestTest {
+    private String date = "Fri, 07 Dec 2012 17:18:00 -0000";
+
+    private static HttpBuilder postHttpBuilder() {
+        // deliberately use the "wrong" case for method and host,
+        // checking that those get canonicalized but URI's case is
+        // preserved.
+        return new Http.HttpBuilder("PoSt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
+    }
+
+    private static HttpBuilder getHttpBuilder() {
+        // deliberately use the "wrong" case for method and host,
+        // checking that those get canonicalized but URI's case is
+        // preserved.
+        return new Http.HttpBuilder("gEt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
+    }
+
+    @Test
+    public void testPostZeroParams() {
+        String actual;
+        String expected = date + "\n"
+                + "POST\n"
+                + "foo.bar52.com\n"
+                + "/Foo/BaR2/qux\n"
+                + "\n"
+                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+
+        Http h = postHttpBuilder().build();
+        try {
+            actual = h.canonRequest(date, 5);
+        } catch (UnsupportedEncodingException e) {
+            Assert.fail(e.toString());
+            return;
+        }
+        Assert.assertEquals("failure - Canonicalization v5 with no params for POST",
+                expected,
+                actual);
+    }
+
+    @Test
+    public void testPostWithParams() {
+        String actual;
+        String expected = date + "\n"
+                + "POST\n"
+                + "foo.bar52.com\n"
+                + "/Foo/BaR2/qux\n"
+                + "\n"
+                + "2664f5a6463b280a814f9177e53161e8dca3a09e941ac75544f1fd27dde2623cd9c375e15330deebfbd9dc538e743cd7dd2a0199128abc8eccc3bede5f627e56";
+
+        Http h = postHttpBuilder().build();
+        h.addParam("data", "abc123");
+
+        try {
+            actual = h.canonRequest(date, 5);
+        } catch (UnsupportedEncodingException e) {
+            Assert.fail(e.toString());
+            return;
+        }
+        Assert.assertEquals("failure - Canonicalization v5 with params for POST",
+                expected,
+                actual);
+    }
+
+    @Test
+    public void testGetZeroParams() {
+        String actual;
+        String expected = date + "\n"
+                + "GET\n"
+                + "foo.bar52.com\n"
+                + "/Foo/BaR2/qux\n"
+                + "\n"
+                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+
+        Http h = getHttpBuilder().build();
+        try {
+            actual = h.canonRequest(date, 5);
+        } catch (UnsupportedEncodingException e) {
+            Assert.fail(e.toString());
+            return;
+        }
+        Assert.assertEquals("failure - Canonicalization v5 with no params for GET",
+                expected,
+                actual);
+    }
+
+    @Test
+    public void testGetWithParams() {
+        String actual;
+        String expected = date + "\n"
+                + "GET\n"
+                + "foo.bar52.com\n"
+                + "/Foo/BaR2/qux\n"
+                + "data=abc123\n"
+                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+
+        Http h = getHttpBuilder().build();
+        h.addParam("data", "abc123");
+        try {
+            actual = h.canonRequest(date, 5);
+        } catch (UnsupportedEncodingException e) {
+            Assert.fail(e.toString());
+            return;
+        }
+        Assert.assertEquals("failure - Canonicalization v5 with params for GET",
+                expected,
+                actual);
+    }
+
+    @Test
+    public void testDuoHeaders() {
+        String actual;
+        String expected = date + "\n"
+                + "POST\n"
+                + "foo.bar52.com\n"
+                + "/Foo/BaR2/qux\n"
+                + "\n"
+                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e\n"
+                + "60be11a30e0756f2ee2afdce1db849b987dcf86c1133394bd7bbbc9877920330c4d78aceacbb377ab8cbd9a8efe6a410fed4047376635ac71226ab46ca10d2b1";
+
+        HttpBuilder httpBuilder = postHttpBuilder();
+        httpBuilder.addAdditionalDuoHeader("x-duo-A", "header_value_1");
+        httpBuilder.addAdditionalDuoHeader("X-duo-B", "header_value_2");
+        Http h = httpBuilder.build();
+        try {
+            actual = h.canonRequest(date, 5);
+        } catch (UnsupportedEncodingException e) {
+            Assert.fail(e.toString());
+            return;
+        }
+        Assert.assertEquals("failure - Canonicalization v5 with additional headers",
+                expected,
+                actual);
+    }
+
+}

--- a/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
@@ -1,18 +1,18 @@
 package com.duosecurity.client;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.ArrayList;
 
 import com.duosecurity.client.Http.HttpBuilder;
-import com.google.common.collect.Collections2;
 import org.junit.Test;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 
 public class HttpCanonV5RequestTest {
     private String date = "Fri, 07 Dec 2012 17:18:00 -0000";
+    private final String hashingAlgorithm = "SHA-512";
+    String hashedBody;
 
     private static HttpBuilder postHttpBuilder() {
         // deliberately use the "wrong" case for method and host,
@@ -28,15 +28,21 @@ public class HttpCanonV5RequestTest {
         return new Http.HttpBuilder("gEt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
     }
 
+    private String getHashedBody(String body) {
+        return Util.bytes_to_hex(Util.hash(hashingAlgorithm, body));
+    }
+
     @Test
     public void testPostZeroParams() {
         String actual;
+        hashedBody = getHashedBody("{}");
+
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+                + hashedBody;
 
         Http h = postHttpBuilder().build();
         try {
@@ -51,17 +57,33 @@ public class HttpCanonV5RequestTest {
     }
 
     @Test
-    public void testPostWithParams() {
+    public void testPostWithParams() throws JSONException {
         String actual;
+        String jsonBody = "{\"data\":\"abc123\",\"alpha\":[\"a\",\"b\",\"c\",\"d\"],\"info\":{\"test\":1,\"anther\":2}}";
+        hashedBody = getHashedBody(jsonBody);
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + "2664f5a6463b280a814f9177e53161e8dca3a09e941ac75544f1fd27dde2623cd9c375e15330deebfbd9dc538e743cd7dd2a0199128abc8eccc3bede5f627e56";
+                + hashedBody;
 
         Http h = postHttpBuilder().build();
         h.addParam("data", "abc123");
+        h.addParam("alpha", new ArrayList<Object>() {
+            {
+                add("a");
+                add("b");
+                add("c");
+                add("d");
+            }
+        });
+        h.addParam("info", new JSONObject() {
+            {
+                put("test", 1);
+                put("anther", 2);
+            }
+        });
 
         try {
             actual = h.canonRequest(date, 5);
@@ -77,12 +99,13 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testGetZeroParams() {
         String actual;
+        hashedBody = getHashedBody("");
         String expected = date + "\n"
                 + "GET\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+                + hashedBody;
 
         Http h = getHttpBuilder().build();
         try {
@@ -99,12 +122,13 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testGetWithParams() {
         String actual;
+        hashedBody = getHashedBody("");
         String expected = date + "\n"
                 + "GET\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "data=abc123\n"
-                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+                + hashedBody;
 
         Http h = getHttpBuilder().build();
         h.addParam("data", "abc123");
@@ -122,12 +146,13 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testDuoHeaders() {
         String actual;
+        hashedBody = getHashedBody("{}");
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e\n"
+                + hashedBody + "\n"
                 + "60be11a30e0756f2ee2afdce1db849b987dcf86c1133394bd7bbbc9877920330c4d78aceacbb377ab8cbd9a8efe6a410fed4047376635ac71226ab46ca10d2b1";
 
         HttpBuilder httpBuilder = postHttpBuilder();

--- a/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
@@ -13,6 +13,7 @@ public class HttpCanonV5RequestTest {
     private String date = "Fri, 07 Dec 2012 17:18:00 -0000";
     private final String hashingAlgorithm = "SHA-512";
     String hashedBody;
+    String hasedEmptyAdditionalHeader = getHashedMessage("");
 
     private static HttpBuilder postHttpBuilder() {
         // deliberately use the "wrong" case for method and host,
@@ -28,21 +29,22 @@ public class HttpCanonV5RequestTest {
         return new Http.HttpBuilder("gEt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
     }
 
-    private String getHashedBody(String body) {
-        return Util.bytes_to_hex(Util.hash(hashingAlgorithm, body));
+    private String getHashedMessage(String message) {
+        return Util.bytes_to_hex(Util.hash(hashingAlgorithm, message));
     }
 
     @Test
     public void testPostZeroParams() {
         String actual;
-        hashedBody = getHashedBody("{}");
+        hashedBody = getHashedMessage("{}");
 
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + hashedBody;
+                + hashedBody + "\n"
+                + hasedEmptyAdditionalHeader;
 
         Http h = postHttpBuilder().build();
         try {
@@ -60,13 +62,14 @@ public class HttpCanonV5RequestTest {
     public void testPostWithParams() throws JSONException {
         String actual;
         String jsonBody = "{\"data\":\"abc123\",\"alpha\":[\"a\",\"b\",\"c\",\"d\"],\"info\":{\"test\":1,\"anther\":2}}";
-        hashedBody = getHashedBody(jsonBody);
+        hashedBody = getHashedMessage(jsonBody);
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + hashedBody;
+                + hashedBody + "\n"
+                + hasedEmptyAdditionalHeader;
 
         Http h = postHttpBuilder().build();
         h.addParam("data", "abc123");
@@ -99,13 +102,14 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testGetZeroParams() {
         String actual;
-        hashedBody = getHashedBody("");
+        hashedBody = getHashedMessage("");
         String expected = date + "\n"
                 + "GET\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "\n"
-                + hashedBody;
+                + hashedBody + "\n"
+                + hasedEmptyAdditionalHeader;
 
         Http h = getHttpBuilder().build();
         try {
@@ -122,13 +126,14 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testGetWithParams() {
         String actual;
-        hashedBody = getHashedBody("");
+        hashedBody = getHashedMessage("");
         String expected = date + "\n"
                 + "GET\n"
                 + "foo.bar52.com\n"
                 + "/Foo/BaR2/qux\n"
                 + "data=abc123\n"
-                + hashedBody;
+                + hashedBody + "\n"
+                + hasedEmptyAdditionalHeader;
 
         Http h = getHttpBuilder().build();
         h.addParam("data", "abc123");
@@ -146,7 +151,7 @@ public class HttpCanonV5RequestTest {
     @Test
     public void testDuoHeaders() {
         String actual;
-        hashedBody = getHashedBody("{}");
+        hashedBody = getHashedMessage("{}");
         String expected = date + "\n"
                 + "POST\n"
                 + "foo.bar52.com\n"

--- a/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
+++ b/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
@@ -149,7 +149,7 @@ public class DuoIntegrations {
             System.out.println("Creating new SSO integration");
             result = (JSONObject) request.executeJSONRequest();
             response = result.getJSONObject("response");
-            System.out.println("Created integration:")
+            System.out.println("Created integration:");
             System.out.println(response);
 
         } catch (Exception e) {

--- a/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
+++ b/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
@@ -1,0 +1,162 @@
+package com.duosecurity.example;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
+import org.json.JSONObject;
+
+import com.duosecurity.client.Http;
+
+public class DuoIntegrations {
+    private static String proxy_host = null;
+    private static int proxy_port = 0;
+
+    public static void main(String[] args) {
+        System.out.println("Duo Integration Demo");
+
+        Options options = new Options();
+        Option opt;
+        opt = new Option("host", true, "API hostname (required)");
+        opt.setRequired(true);
+        options.addOption(opt);
+        opt = new Option("ikey", true, "Admin API integration key (required)");
+        opt.setRequired(true);
+        options.addOption(opt);
+        opt = new Option("skey", true, "Secret key (required)");
+        opt.setRequired(true);
+        options.addOption(opt);
+        opt = new Option("proxy", true, "host:port for HTTPS CONNECT proxy");
+        opt.setRequired(false);
+        options.addOption(opt);
+        options.addOption("help", false, "Print this message");
+
+        CommandLineParser parser = new PosixParser();
+        HelpFormatter formatter = new HelpFormatter();
+        CommandLine cmd;
+        try {
+            cmd = parser.parse(options, args);
+        } catch (ParseException parseException) {
+            System.err.println(parseException.getMessage());
+            formatter.printHelp("DuoAdmin", options);
+            System.exit(1);
+            return;
+        }
+
+        if (cmd.hasOption("help")) {
+            formatter.printHelp("DuoAdmin", options);
+            System.exit(0);
+        }
+
+        if (cmd.hasOption("proxy")) {
+            Pattern p = Pattern.compile("^([^:]+):(\\d{1,5})$");
+            Matcher m = p.matcher(cmd.getOptionValue("proxy"));
+            if (m.find()) {
+                proxy_host = m.group(1);
+                proxy_port = Integer.parseInt(m.group(2));
+            } else {
+                System.out.println("Invalid proxy.");
+                System.exit(1);
+                return;
+            }
+        }
+        create_integration(cmd);
+        System.out.println("Done with Integration API demo.");
+    }
+
+    private static void create_integration(CommandLine cmd) {
+        JSONObject result;
+        JSONObject response;
+
+        try {
+            // Prepare request.
+            Http request = new Http.HttpBuilder("POST", cmd.getOptionValue("host"), "/admin/v2/integrations").build();
+            request.addParam("name", "api-created integration");
+            request.addParam("type", "sso-generic");
+            request.addParam("sso", new JSONObject() {
+                {
+                    put("saml_config", new JSONObject() {
+                        {
+                            put("entity_id", "entity_id");
+                            put("acs_urls", new ArrayList<Object>() {
+                                {
+                                    add(
+                                            new JSONObject() {
+                                                {
+                                                    put("url", "https://example.com/acs");
+                                                    put("binding", JSONObject.NULL);
+                                                    put("isDefault", JSONObject.NULL);
+                                                    put("index", JSONObject.NULL);
+                                                }
+                                            });
+                                }
+                            });
+                            put("nameid_format", "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
+                            put("nameid_attribute", "mail");
+                            put("sign_assertion", false);
+                            put("sign_response", true);
+                            put("signing_algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
+                            put("mapped_attrs", new JSONObject());
+                            put("relaystate", "https://example.com/relaystate");
+                            put("slo_url", "https://example.com/slo");
+                            put("spinitiated_url", "https://example.com/spurl");
+                            put("static_attrs", new JSONObject());
+                            put("role_attrs", new JSONObject() {
+                                {
+                                    put("bob", new JSONObject() {
+                                        {
+                                            put("ted", new ArrayList<String>() {
+                                                {
+                                                    add("DGS08MMO53GNRLSFW0D0");
+                                                    add("DGETXINZ6CSJO4LRSVKV");
+                                                }
+                                            });
+                                            put("frank", new ArrayList<String>() {
+                                                {
+                                                    add("DGETXINZ6CSJO4LRSVKV");
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
+                            });
+                            put("attribute_transformations", new JSONObject() {
+                                {
+                                    put("attribute_1", "use \"<Username>\"\nprepend text=\"dev-\"");
+                                    put("attribute_2",
+                                            "use \"<Email Address>\"\nappend additional_attr=\"<First Name>\"");
+                                }
+                            });
+
+                        }
+                    });
+                }
+            });
+            request.signRequest(cmd.getOptionValue("ikey"), cmd.getOptionValue("skey"), 5);
+
+            // Use proxy if one was specified.
+            if (proxy_host != null) {
+                request.setProxy(proxy_host, proxy_port);
+            }
+
+            System.out.println("Creating new SSO integration");
+            result = (JSONObject) request.executeJSONRequest();
+            response = result.getJSONObject("response");
+            System.out.println("Created integration:")
+            System.out.println(response);
+
+        } catch (Exception e) {
+            System.out.println("error making request");
+            System.out.println(e.toString());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR is made based on feedback what params should looks like.
The params changed from <String, String> to <String, Object>
- Add hash algorithm 
- Implement c5 to canonRequest
- Change prams to TreeMap get sort for free
- Add tests for c5 with detailed hashed body
- allow client add different type of params
- Add sso integration example.