### PR TITLE
Add support for signature version 5

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -216,7 +216,7 @@ public class Http {
    */
   public void signRequest(String ikey, String skey, int inSigVersion)
       throws UnsupportedEncodingException {
-    int[] availableSigVersion = {1, 2};
+    int[] availableSigVersion = {1, 2, 5};
 
     if (Arrays.stream(availableSigVersion).anyMatch(i -> i == inSigVersion)){
       sigVersion = inSigVersion;
@@ -228,7 +228,7 @@ public class Http {
     String auth = ikey + ":" + sig;
     String header = "Basic " + Base64.encodeBytes(auth.getBytes());
     addHeader("Authorization", header);
-    if (sigVersion == 2) {
+    if (sigVersion == 2 || sigVersion == 5) {
       addHeader("Date", date);
     }
   }


### PR DESCRIPTION
Signature version 2 and 5 are the same other than the fact that v2 allows SHA-1 signing. duo_client_java is hardcoded to always use SHA-512, however, so it was already operating in a v5-compatible way. The signing method just needed to be updated to treat version 5 as a valid signing version. 