### PR TITLE
Create Auth, Accounts, and Admin subtypes for the client

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Accounts.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Accounts.java
@@ -1,0 +1,19 @@
+package com.duosecurity.client;
+
+public class Accounts extends Http {
+    private Accounts(String inMethod, String inHost, String inUri, int timeout) {
+        super(inMethod, inHost, inUri, timeout);
+    }
+
+    public static class AccountsBuilder extends HttpBuilder<Accounts> {
+
+        public AccountsBuilder(String method, String host, String uri) {
+            super(method, host, uri);
+        }
+
+        @Override
+        protected Accounts createClient(String method, String host, String uri, int timeout) {
+            return new Accounts(method, host, uri, timeout);
+        }
+    }
+}

--- a/duo-client/src/main/java/com/duosecurity/client/Admin.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Admin.java
@@ -1,0 +1,21 @@
+package com.duosecurity.client;
+
+public class Admin extends Http {
+    private Admin(String inMethod, String inHost, String inUri, int timeout) {
+        super(inMethod, inHost, inUri, timeout);
+    }
+
+    public static class AdminBuilder extends HttpBuilder<Admin> {
+
+        public AdminBuilder(String method, String host, String uri) {
+            super(method, host, uri);
+        }
+
+        @Override
+        protected Admin createClient(String method, String host, String uri, int timeout) {
+            return new Admin(method, host, uri, timeout);
+        }
+
+    }
+}
+

--- a/duo-client/src/main/java/com/duosecurity/client/Auth.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Auth.java
@@ -1,0 +1,21 @@
+package com.duosecurity.client;
+
+public class Auth extends Http {
+    private Auth(String inMethod, String inHost, String inUri, int timeout) {
+        super(inMethod, inHost, inUri, timeout);
+    }
+
+    public static class AuthBuilder extends HttpBuilder<Auth> {
+
+        public AuthBuilder(String method, String host, String uri) {
+            super(method, host, uri);
+        }
+
+        @Override
+        protected Auth createClient(String method, String host, String uri, int timeout) {
+            return new Auth(method, host, uri, timeout);
+        }
+
+    }
+}
+

--- a/duo-client/src/test/java/com/duosecurity/client/HttpAdditionalHeadersTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpAdditionalHeadersTest.java
@@ -3,25 +3,25 @@ package com.duosecurity.client;
 
 import org.junit.Test;
 
-import com.duosecurity.client.Http.HttpBuilder;
+import com.duosecurity.client.Admin.AdminBuilder;
 
 import org.junit.Assert;
 
 public class HttpAdditionalHeadersTest {
-    private static HttpBuilder makeHttpBuilder() {
-        return new Http.HttpBuilder("GET", "example.test", "/foo/bar");
+    private static AdminBuilder makeAdminBuilder() {
+        return new Admin.AdminBuilder("GET", "example.test", "/foo/bar");
     }
 
     @Test
     public void testAddHeaders(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         h.addAdditionalDuoHeader("X-Duo-Header-1", "header_value_1");
         h.addAdditionalDuoHeader("X-Duo-Header-2", "header_value_2");
     }
 
     @Test
     public void testNullHeaderName(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         try {
             h.addAdditionalDuoHeader(null, "header_value_1");
         }
@@ -35,7 +35,7 @@ public class HttpAdditionalHeadersTest {
     }
     @Test
     public void testEmptyHeaderName(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         try {
             h.addAdditionalDuoHeader("", "header_value_1");
         }
@@ -50,7 +50,7 @@ public class HttpAdditionalHeadersTest {
 
     @Test
     public void testNullHeaderValue(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         try {
             h.addAdditionalDuoHeader("X-Duo-Header-1", null);
         }
@@ -65,7 +65,7 @@ public class HttpAdditionalHeadersTest {
 
     @Test
     public void testEmptyHeaderValue(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         try {
             h.addAdditionalDuoHeader("X-Duo-Header-1", "");
         }
@@ -80,7 +80,7 @@ public class HttpAdditionalHeadersTest {
 
     @Test
     public void testNonDuoHeader(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         try {
             h.addAdditionalDuoHeader("X-not-Duo-Header-1", "header_value_1");
         }
@@ -95,7 +95,7 @@ public class HttpAdditionalHeadersTest {
 
     @Test
     public void testDuplicatedHeader(){
-        HttpBuilder h = makeHttpBuilder();
+        AdminBuilder h = makeAdminBuilder();
         h.addAdditionalDuoHeader("X-Duo-Header-1", "header_value_1");
         try {
             h.addAdditionalDuoHeader("X-DUO-Header-1", "header_value_1");

--- a/duo-client/src/test/java/com/duosecurity/client/HttpCanonRequestTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpCanonRequestTest.java
@@ -15,11 +15,11 @@ public class HttpCanonRequestTest {
         + "foo.bar52.com\n"
         + "/Foo/BaR2/qux\n";
 
-    private static Http makeHttp() {
+    private static Auth makeAuth() {
         // deliberately use the "wrong" case for method and host,
         // checking that those get canonicalized but URI's case is
         // preserved.
-        return new Http.HttpBuilder("PoSt", "foO.BAr52.cOm", "/Foo/BaR2/qux").build();
+        return new Auth.AuthBuilder("PoSt", "foO.BAr52.cOm", "/Foo/BaR2/qux").build();
     }
 
     private void assertCanonRequest(String expected_query_string,
@@ -28,7 +28,7 @@ public class HttpCanonRequestTest {
                  : Collections2.permutations(Arrays.asList(params))) {
             String actual;
 
-            Http h = makeHttp();
+            Http h = makeAuth();
             for (String[] kv : a_params) {
                 h.addParam(kv[0], kv[1]);
             }

--- a/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpCanonV5RequestTest.java
@@ -3,7 +3,7 @@ package com.duosecurity.client;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
-import com.duosecurity.client.Http.HttpBuilder;
+import com.duosecurity.client.Admin.AdminBuilder;
 import org.junit.Test;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,18 +15,18 @@ public class HttpCanonV5RequestTest {
     String hashedBody;
     String hasedEmptyAdditionalHeader = getHashedMessage("");
 
-    private static HttpBuilder postHttpBuilder() {
+    private static AdminBuilder postAdminBuilder() {
         // deliberately use the "wrong" case for method and host,
         // checking that those get canonicalized but URI's case is
         // preserved.
-        return new Http.HttpBuilder("PoSt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
+        return new Admin.AdminBuilder("PoSt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
     }
 
-    private static HttpBuilder getHttpBuilder() {
+    private static AdminBuilder getAdminBuilder() {
         // deliberately use the "wrong" case for method and host,
         // checking that those get canonicalized but URI's case is
         // preserved.
-        return new Http.HttpBuilder("gEt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
+        return new Admin.AdminBuilder("gEt", "foO.BAr52.cOm", "/Foo/BaR2/qux");
     }
 
     private String getHashedMessage(String message) {
@@ -46,7 +46,7 @@ public class HttpCanonV5RequestTest {
                 + hashedBody + "\n"
                 + hasedEmptyAdditionalHeader;
 
-        Http h = postHttpBuilder().build();
+        Admin h = postAdminBuilder().build();
         try {
             actual = h.canonRequest(date, 5);
         } catch (UnsupportedEncodingException e) {
@@ -71,7 +71,7 @@ public class HttpCanonV5RequestTest {
                 + hashedBody + "\n"
                 + hasedEmptyAdditionalHeader;
 
-        Http h = postHttpBuilder().build();
+        Admin h = postAdminBuilder().build();
         h.addParam("data", "abc123");
         h.addParam("alpha", new ArrayList<Object>() {
             {
@@ -111,7 +111,7 @@ public class HttpCanonV5RequestTest {
                 + hashedBody + "\n"
                 + hasedEmptyAdditionalHeader;
 
-        Http h = getHttpBuilder().build();
+        Admin h = getAdminBuilder().build();
         try {
             actual = h.canonRequest(date, 5);
         } catch (UnsupportedEncodingException e) {
@@ -135,7 +135,7 @@ public class HttpCanonV5RequestTest {
                 + hashedBody + "\n"
                 + hasedEmptyAdditionalHeader;
 
-        Http h = getHttpBuilder().build();
+        Admin h = getAdminBuilder().build();
         h.addParam("data", "abc123");
         try {
             actual = h.canonRequest(date, 5);
@@ -160,10 +160,10 @@ public class HttpCanonV5RequestTest {
                 + hashedBody + "\n"
                 + "60be11a30e0756f2ee2afdce1db849b987dcf86c1133394bd7bbbc9877920330c4d78aceacbb377ab8cbd9a8efe6a410fed4047376635ac71226ab46ca10d2b1";
 
-        HttpBuilder httpBuilder = postHttpBuilder();
+        AdminBuilder httpBuilder = postAdminBuilder();
         httpBuilder.addAdditionalDuoHeader("x-duo-A", "header_value_1");
         httpBuilder.addAdditionalDuoHeader("X-duo-B", "header_value_2");
-        Http h = httpBuilder.build();
+        Admin h = httpBuilder.build();
         try {
             actual = h.canonRequest(date, 5);
         } catch (UnsupportedEncodingException e) {

--- a/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpRateLimitRetryTest.java
@@ -14,7 +14,6 @@ import org.mockito.stubbing.Answer;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
@@ -29,7 +28,7 @@ public class HttpRateLimitRetryTest {
 
     @Before
     public void before() throws Exception {
-        http = new Http.HttpBuilder("GET", "example.test", "/foo/bar").build();
+        http = new Accounts.AccountsBuilder("GET", "example.test", "/foo/bar").build();
         http = Mockito.spy(http);
 
         Field httpClientField = Http.class.getDeclaredField("httpClient");

--- a/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpSignHMACTest.java
@@ -6,7 +6,7 @@ import org.junit.Assert;
 
 public class HttpSignHMACTest {
     private static Http makeHttp() {
-        return new Http.HttpBuilder("get", "API.test", "/v1/tEst").build();
+        return new Auth.AuthBuilder("get", "API.test", "/v1/tEst").build();
     }
 
     @Test

--- a/duo-example-admin/src/main/java/com/duosecurity/example/DuoAdmin.java
+++ b/duo-example-admin/src/main/java/com/duosecurity/example/DuoAdmin.java
@@ -6,7 +6,7 @@ package com.duosecurity.example;
  * Documentation: http://www.duosecurity.com/docs/adminapi
  */
 
-import com.duosecurity.client.Http;
+import com.duosecurity.client.Admin;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -88,9 +88,9 @@ public class DuoAdmin {
     JSONObject result = null;
     try {
       // Prepare request.
-      Http request = new Http.HttpBuilder("GET",
-                              cmd.getOptionValue("host"),
-                              "/admin/v1/info/authentication_attempts").build();
+      Admin request = new Admin.AdminBuilder("GET",
+                                cmd.getOptionValue("host"),
+                                "/admin/v1/info/authentication_attempts").build();
       request.signRequest(cmd.getOptionValue("ikey"),
                           cmd.getOptionValue("skey"));
 
@@ -123,7 +123,7 @@ public class DuoAdmin {
     JSONObject metadata;
     try {
       // Prepare request.
-      Http request = new Http.HttpBuilder("GET", cmd.getOptionValue("host"), "/admin/v1/users").build();
+      Admin request = new Admin.AdminBuilder("GET", cmd.getOptionValue("host"), "/admin/v1/users").build();
       String limit = "10";
       request.addParam("offset", "0");
       request.addParam("limit", limit);
@@ -147,7 +147,7 @@ public class DuoAdmin {
         if (!metadata.isNull("next_offset")) {
           offset = metadata.getInt("next_offset");
 
-          request = new Http.HttpBuilder("GET", cmd.getOptionValue("host"), "/admin/v1/users").build();
+          request = new Admin.AdminBuilder("GET", cmd.getOptionValue("host"), "/admin/v1/users").build();
           request.addParam("offset", Integer.toString(offset));
           request.addParam("limit", limit);
           request.signRequest(cmd.getOptionValue("ikey"), cmd.getOptionValue("skey"));

--- a/duo-example-admin/src/main/java/com/duosecurity/example/DuoAuthLogsV2.java
+++ b/duo-example-admin/src/main/java/com/duosecurity/example/DuoAuthLogsV2.java
@@ -19,7 +19,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 
-import com.duosecurity.client.Http;
+import com.duosecurity.client.Admin;
 
 public class DuoAuthLogsV2 {
     private static String proxy_host = null;
@@ -83,7 +83,7 @@ public class DuoAuthLogsV2 {
         JSONObject metadata;
         try {
             // Prepare request.
-            Http request = new Http.HttpBuilder("GET", cmd.getOptionValue("host"), "/admin/v2/logs/authentication").build();
+            Admin request = new Admin.AdminBuilder("GET", cmd.getOptionValue("host"), "/admin/v2/logs/authentication").build();
             String limit = "2";
             long mintime = System.currentTimeMillis() - (180 * 24 * 60 * 60 * 100);
             long maxtime = System.currentTimeMillis();
@@ -112,7 +112,7 @@ public class DuoAuthLogsV2 {
                 if (!metadata.isNull("next_offset")) {
                     System.out.println("Getting more logs...");
 					offset = metadata.getJSONArray("next_offset");
-                    request = new Http.HttpBuilder("GET", cmd.getOptionValue("host"), "/admin/v2/logs/authentication").build();
+                    request = new Admin.AdminBuilder("GET", cmd.getOptionValue("host"), "/admin/v2/logs/authentication").build();
                     next_offset = offset.get(0).toString() + ',' + offset.get(1).toString();
                     request.addParam("next_offset", next_offset);
                     request.addParam("limit", limit);

--- a/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
+++ b/duo-example-admin/src/main/java/com/duosecurity/example/DuoIntegrations.java
@@ -13,7 +13,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.json.JSONObject;
 
-import com.duosecurity.client.Http;
+import com.duosecurity.client.Admin;
 
 public class DuoIntegrations {
     private static String proxy_host = null;
@@ -77,7 +77,7 @@ public class DuoIntegrations {
 
         try {
             // Prepare request.
-            Http request = new Http.HttpBuilder("POST", cmd.getOptionValue("host"), "/admin/v2/integrations").build();
+            Admin request = new Admin.AdminBuilder("POST", cmd.getOptionValue("host"), "/admin/v2/integrations").build();
             request.addParam("name", "api-created integration");
             request.addParam("type", "sso-generic");
             request.addParam("sso", new JSONObject() {


### PR DESCRIPTION
This does break backwards compatibility - the base Http client cannot be created anymore.  I think this is the right decision for the long term, but open to discussion.