### PR TITLE
Stop using deprecated maven plugin option

### DIFF
--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -96,7 +96,7 @@
             <id>make-assembly</id>
             <phase>package</phase>
             <goals>
-              <goal>attached</goal>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
per https://maven.apache.org/plugins-archives/maven-assembly-plugin-2.5.5/attached-mojo.html 'attached' is deprecated

## Description
Update the pom to stop using a deprecated maven option

## Motivation and Context
Gets rid of a ticking time bomb in our CI

## How Has This Been Tested?
build passes locally, should pass CI

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
