### PR TITLE
add new addParam to allow JSONArray for new api param type

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -23,7 +23,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -23,6 +23,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class Http {
@@ -280,6 +282,10 @@ public class Http {
   }
 
   public void addParam(String name, List<Object> value) {
+    params.put(name, value);
+  }
+
+  public void addParam(String name, JSONArray value) {
     params.put(name, value);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The new `username_list` admin api require a JSON serialized array as value.
## Description
<!--- Describe your changes -->
This PR add JSONArray type as acceptable type for addParam function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It would be possible to use `username_list` without this PR, you could in client, pass in use `.toString()` for the
json array. This PR just make it slightly easiler to use it.
## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
