### PR TITLE
Bump okhttp version to 4.12.0 to resolve CVE-2023-3635, CVE-2022-24329

### DIFF
--- a/duo-client/pom.xml
+++ b/duo-client/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.10.0</version>
+      <version>4.12.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Description
Upgrade okhttp dependency from 4.10.0 to 4.12.0 in order to resolve vulnerabilities present in transient dependency okio.

[CVE-2023-3635](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-3635): Older versions of okio's GzipSource.kt contain a vulnerability that may allow attackers to execute denial of service attacks. This vulnerability is present in okio versions starting at 2.0.0, [patched in 3.4.0](https://github.com/square/okio/commit/81bce1a30af244550b0324597720e4799281da7b). Duo-client currently leverages okhttp version 4.10.10, which includes okio version 3.0.0 as a dependency. 

[CVE-2022-24329](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24329): Older versions of okio and okhttp also include as dependencies kotlin-stdlib-jdk8 version 1.5.31 and kotlin-stdlib-common version 1.5.31, which are vulnerable to [improper locking](https://cwe.mitre.org/data/definitions/667.html).

Both of these vulnerabilities can be resolved by upgrading okhttp from 4.10.0 to 4.12.0.

Current dependency tree:
```+- com.squareup.okhttp3:okhttp:jar:4.10.0:compile
|  +- com.squareup.okio:okio-jvm:jar:3.0.0:compile
|  |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31:compile
|  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31:compile
|  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31:compile
|  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile
|     \- org.jetbrains:annotations:jar:13.0:compile
```

Dependency tree with patch applied:
```+- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
|  +- com.squareup.okio:okio:jar:3.6.0:compile
|  |  \- com.squareup.okio:okio-jvm:jar:3.6.0:compile
|  |     \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.9.10:compile
|  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.21:compile
|     +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.8.21:compile
|     |  \- org.jetbrains:annotations:jar:13.0:compile
|     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.21:compile
```

## Motivation and Context
Patches open vulnerabilities with one minor version increment.

## How Has This Been Tested?
Ran `mvn test` locally. 10 passed, 11 failed:

```
Failed tests:   testPrintableASCII(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testUnicodeFuzzValues(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testZeroParams(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testSimple(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testOneParam(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testUnicodeFuzzKeysAndValues(com.duosecurity.client.HttpCanonRequestTest): failure - sig_version = 1 expected:<POST[
  testDuoHeaders(com.duosecurity.client.HttpCanonV5RequestTest): failure - Canonicalization v5 with additional headers expected:<... 2012 17:18:00 -0000[
  testGetZeroParams(com.duosecurity.client.HttpCanonV5RequestTest): failure - Canonicalization v5 with no params for GET expected:<... 2012 17:18:00 -0000[
  testPostZeroParams(com.duosecurity.client.HttpCanonV5RequestTest): failure - Canonicalization v5 with no params for POST expected:<... 2012 17:18:00 -0000[
  testGetWithParams(com.duosecurity.client.HttpCanonV5RequestTest): failure - Canonicalization v5 with params for GET expected:<... 2012 17:18:00 -0000[
  testPostWithParams(com.duosecurity.client.HttpCanonV5RequestTest): failure - Canonicalization v5 with params for POST expected:<... 2012 17:18:00 -0000[
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
