### PR TITLE
Resolve line ending canonicalization issue on Windows

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -314,30 +314,30 @@ public class Http {
     String canonParam;
     String canonBody;
     if (sigVersion == 1) {
-      canon += method.toUpperCase() + System.lineSeparator();
-      canon += host.toLowerCase() + System.lineSeparator();
-      canon += uri + System.lineSeparator();
+      canon += method.toUpperCase() + "\n";
+      canon += host.toLowerCase() + "\n";
+      canon += uri + "\n";
       canon += canonQueryString();
     } else if (sigVersion == 2) {
-      canon += date + System.lineSeparator();
-      canon += method.toUpperCase() + System.lineSeparator();
-      canon += host.toLowerCase() + System.lineSeparator();
-      canon += uri + System.lineSeparator();
+      canon += date + "\n";
+      canon += method.toUpperCase() + "\n";
+      canon += host.toLowerCase() + "\n";
+      canon += uri + "\n";
       canon += canonQueryString();
     } else if (sigVersion == 5) {
-      canon += date + System.lineSeparator();
-      canon += method.toUpperCase() + System.lineSeparator();
-      canon += host.toLowerCase() + System.lineSeparator();
-      canon += uri + System.lineSeparator();
+      canon += date + "\n";
+      canon += method.toUpperCase() + "\n";
+      canon += host.toLowerCase() + "\n";
+      canon += uri + "\n";
       if ("POST".equals(method) || "PUT".equals(method)) {
-        canonParam = System.lineSeparator();
+        canonParam = "\n";
         canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonJSONBody()));
       } else {
-        canonParam = canonQueryString() + System.lineSeparator();
+        canonParam = canonQueryString() + "\n";
         canonBody = Util.bytes_to_hex(Util.hash(hashingAlgorithm, ""));
       }
       canon += canonParam;
-      canon += canonBody + System.lineSeparator();
+      canon += canonBody + "\n";
       canon += Util.bytes_to_hex(Util.hash(hashingAlgorithm, canonXDuoHeaders()));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The 0.6.x versions of the client use the System.lineSeparator() method for line endings. On Windows systems, this method returns a CRLF, but Duo requires the signature input to be canonicalized with only a line feed. I reverted this behavior by directly inserting "\n" for line separators.

## Motivation and Context
This allows the project to be built and run on Windows systems. Without this change, all invocations of the client from Windows returns an invalid signature error.

## How Has This Been Tested?
Unit and function tested on Windows 10 and Ubuntu.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
