### PR TITLE
Handle the case where the code object in the response is not an integer

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -127,7 +127,7 @@ public class Http {
     JSONObject result = new JSONObject(executeRequestRaw());
     if (!result.getString("stat").equals("OK")) {
       throw new Exception("Duo error code ("
-          + result.getInt("code")
+          + result.get("code").toString()
           + "): "
           + result.getString("message"));
     }


### PR DESCRIPTION
## Description
When we string-ify the information for a failed api call, we were assuming the 'code' is always an integer.  There is at least one scenario where that is not the case, so don't make that assumption.  There was no real reason to assume it was anyway, since we were just turning around and converting it to a string anyway.

## Motivation and Context
Fixes an unchecked exception that occurs if an api call returns a non-integer code value

## How Has This Been Tested?
Not covered by tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
