### PR TITLE
Add builder option to disable CA certificate pinning

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -438,6 +438,16 @@ public class Http {
     httpClient = httpClient.newBuilder().certificatePinner(pinner).build();
   }
 
+  /**
+   * Disable CA certificate pinning. TLS verification remains active
+   * via the OS trust store.
+   */
+  public void disableCaPinning() {
+    httpClient = httpClient.newBuilder()
+        .certificatePinner(CertificatePinner.DEFAULT)
+        .build();
+  }
+
   protected String canonRequest(String date, int sigVersion)
       throws UnsupportedEncodingException {
     String canon = "";
@@ -543,6 +553,7 @@ public class Http {
     private int timeout = DEFAULT_TIMEOUT_SECS;
     private long maxBackoffMs = MAX_BACKOFF_MS;
     private String[] caCerts = null;
+    private boolean disableCaPinning = false;
     private SortedMap<String, String> additionalDuoHeaders = new TreeMap<String, String>();
     private Map<String, String> headers = new HashMap<String, String>();
 
@@ -610,6 +621,19 @@ public class Http {
     }
 
     /**
+     * Disable CA certificate pinning. TLS verification remains active
+     * via the OS trust store.
+     *
+     * @return the Builder
+     * @throws IllegalStateException if custom certificates have also been set
+     */
+    public ClientBuilder<T> disableCaPinning() {
+      this.disableCaPinning = true;
+
+      return this;
+    }
+
+    /**
      * Set additional x-duo header for the HTTP client.
      *
      * @param name  Header's name
@@ -642,10 +666,17 @@ public class Http {
      * @return the specified Http client object
      */
     public T build() {
+      if (disableCaPinning && caCerts != null) {
+        throw new IllegalStateException(
+            "Cannot both disable CA pinning and provide custom certificates");
+      }
       T duoClient = createClient(method, host, uri, timeout);
       duoClient.setMaxBackoffMs(maxBackoffMs);
       if (caCerts != null) {
         duoClient.useCustomCertificates(caCerts);
+      }
+      if (disableCaPinning) {
+        duoClient.disableCaPinning();
       }
       if (additionalDuoHeaders != null) {
         duoClient.addAdditionalDuoHeader(additionalDuoHeaders);

--- a/duo-client/src/test/java/com/duosecurity/client/HttpDisableCaPinningTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpDisableCaPinningTest.java
@@ -1,0 +1,63 @@
+package com.duosecurity.client;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import okhttp3.CertificatePinner;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
+
+public class HttpDisableCaPinningTest {
+
+  private OkHttpClient getHttpClient(Http http) throws Exception {
+    Field httpClientField = Http.class.getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+    return (OkHttpClient) httpClientField.get(http);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<?> getPins(CertificatePinner pinner) throws Exception {
+    Field pinsField = CertificatePinner.class.getDeclaredField("pins");
+    pinsField.setAccessible(true);
+    return (Set<?>) pinsField.get(pinner);
+  }
+
+  @Test
+  public void testDisableCaPinning_removesPin() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .disableCaPinning()
+        .build();
+
+    OkHttpClient client = getHttpClient(http);
+    Set<?> pins = getPins(client.certificatePinner());
+    assertTrue("Pins should be empty when CA pinning is disabled", pins.isEmpty());
+  }
+
+  @Test
+  public void testDefaultBuilder_hasPinning() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .build();
+
+    OkHttpClient client = getHttpClient(http);
+    Set<?> pins = getPins(client.certificatePinner());
+    assertFalse("Pins should not be empty by default", pins.isEmpty());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testDisableAndCustomCerts_throws() {
+    new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .disableCaPinning()
+        .useCustomCertificates(new String[]{"sha256/test"})
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCustomCertsAndDisable_throws() {
+    new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .useCustomCertificates(new String[]{"sha256/test"})
+        .disableCaPinning()
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `disableCaPinning()` method to `Http` and `ClientBuilder` that removes CA pin checks while keeping TLS verification active via the OS trust store
- Throws `IllegalStateException` at build time if both `disableCaPinning()` and `useCustomCertificates()` are set (mutually exclusive)
- Uses the same `newBuilder()` pattern as `setProxy()` and `useCustomCertificates()`

## Test plan

- [x] Unit tests verify pinning is removed (empty pin set via reflection)
- [x] Unit tests verify default behavior unchanged (pin set non-empty)
- [x] Unit tests verify mutual exclusivity throws `IllegalStateException`
- [x] Manual test confirmed both paths succeed against `api-483c5af7.test.duosecurity.com`
- [x] Full test suite passes (29 tests)
- [x] Checkstyle passes

*This PR was generated with AI assistance (Claude).*