### PR TITLE
Add CA bundle version and pinning status to user agent string

### DIFF
--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -32,6 +32,7 @@ public class Http {
   public static final int DEFAULT_TIMEOUT_SECS = 60;
   private static final int RATE_LIMIT_ERROR_CODE = 429;
 
+  private static final String CA_BUNDLE_VERSION = "1.0";
   public static final String UserAgentString = "Duo API Java/0.8.1-SNAPSHOT";
 
   private final String method;
@@ -223,7 +224,8 @@ public class Http {
 
     headers = new Headers.Builder();
     headers.add("Host", host);
-    headers.add("user-agent", UserAgentString);
+    headers.add("user-agent", String.format("%s ca_bundle/%s (ca_pinning=%s)",
+        UserAgentString, CA_BUNDLE_VERSION, "enabled"));
 
     CertificatePinner pinner = Util.createPinner(host, DEFAULT_CA_CERTS);
 
@@ -395,6 +397,10 @@ public class Http {
 
   public void addHeader(String name, String value) {
     headers.add(name, value);
+  }
+
+  void setHeader(String name, String value) {
+    headers.set(name, value);
   }
 
   public void addParam(String name, String value) {
@@ -675,6 +681,9 @@ public class Http {
       if (caCerts != null) {
         duoClient.useCustomCertificates(caCerts);
       }
+      String caPinningStatus = disableCaPinning ? "disabled" : "enabled";
+      duoClient.setHeader("user-agent", String.format("%s ca_bundle/%s (ca_pinning=%s)",
+          UserAgentString, CA_BUNDLE_VERSION, caPinningStatus));
       if (disableCaPinning) {
         duoClient.disableCaPinning();
       }

--- a/duo-client/src/main/java/com/duosecurity/client/Http.java
+++ b/duo-client/src/main/java/com/duosecurity/client/Http.java
@@ -681,9 +681,6 @@ public class Http {
       if (caCerts != null) {
         duoClient.useCustomCertificates(caCerts);
       }
-      String caPinningStatus = disableCaPinning ? "disabled" : "enabled";
-      duoClient.setHeader("user-agent", String.format("%s ca_bundle/%s (ca_pinning=%s)",
-          UserAgentString, CA_BUNDLE_VERSION, caPinningStatus));
       if (disableCaPinning) {
         duoClient.disableCaPinning();
       }
@@ -696,6 +693,9 @@ public class Http {
           duoClient.addHeader(name, value);
         }
       }
+      String caPinningStatus = disableCaPinning ? "disabled" : "enabled";
+      duoClient.setHeader("user-agent", String.format("%s ca_bundle/%s (ca_pinning=%s)",
+          UserAgentString, CA_BUNDLE_VERSION, caPinningStatus));
 
       return duoClient;
     }

--- a/duo-client/src/test/java/com/duosecurity/client/HttpUserAgentTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpUserAgentTest.java
@@ -1,5 +1,6 @@
 package com.duosecurity.client;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
@@ -8,11 +9,15 @@ import org.junit.Test;
 
 public class HttpUserAgentTest {
 
-  private String getUserAgent(Http http) throws Exception {
+  private Headers getHeaders(Http http) throws Exception {
     Field headersField = Http.class.getDeclaredField("headers");
     headersField.setAccessible(true);
     Headers.Builder headersBuilder = (Headers.Builder) headersField.get(http);
-    return headersBuilder.build().get("user-agent");
+    return headersBuilder.build();
+  }
+
+  private String getUserAgent(Http http) throws Exception {
+    return getHeaders(http).get("user-agent");
   }
 
   @Test
@@ -50,5 +55,17 @@ public class HttpUserAgentTest {
     String userAgent = getUserAgent(http);
     assertTrue(userAgent.contains("ca_bundle/1.0"));
     assertTrue(userAgent.contains("(ca_pinning=enabled)"));
+  }
+
+  @Test
+  public void testCustomUserAgentHeader_isReplacedNotDuplicated() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .addHeader("user-agent", "MyApp/1.0")
+        .build();
+
+    Headers headers = getHeaders(http);
+    assertEquals(1, headers.values("user-agent").size());
+    assertEquals(String.format("%s ca_bundle/1.0 (ca_pinning=enabled)", Http.UserAgentString),
+        headers.get("user-agent"));
   }
 }

--- a/duo-client/src/test/java/com/duosecurity/client/HttpUserAgentTest.java
+++ b/duo-client/src/test/java/com/duosecurity/client/HttpUserAgentTest.java
@@ -1,0 +1,54 @@
+package com.duosecurity.client;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import okhttp3.Headers;
+import org.junit.Test;
+
+public class HttpUserAgentTest {
+
+  private String getUserAgent(Http http) throws Exception {
+    Field headersField = Http.class.getDeclaredField("headers");
+    headersField.setAccessible(true);
+    Headers.Builder headersBuilder = (Headers.Builder) headersField.get(http);
+    return headersBuilder.build().get("user-agent");
+  }
+
+  @Test
+  public void testDefaultBuilder_includesCaBundleVersion() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .build();
+
+    String userAgent = getUserAgent(http);
+    assertTrue(userAgent.contains("ca_bundle/1.0"));
+  }
+
+  @Test
+  public void testDefaultBuilder_includesCaPinningEnabled() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .build();
+
+    String userAgent = getUserAgent(http);
+    assertTrue(userAgent.contains("(ca_pinning=enabled)"));
+  }
+
+  @Test
+  public void testDisableCaPinning_includesCaPinningDisabled() throws Exception {
+    Http http = new Http.HttpBuilder("GET", "api-host.duosecurity.com", "/auth/v2/check")
+        .disableCaPinning()
+        .build();
+
+    String userAgent = getUserAgent(http);
+    assertTrue(userAgent.contains("(ca_pinning=disabled)"));
+  }
+
+  @Test
+  public void testLegacyConstructor_includesCaBundleAndPinningEnabled() throws Exception {
+    Http http = new Http("GET", "api-host.duosecurity.com", "/auth/v2/check");
+
+    String userAgent = getUserAgent(http);
+    assertTrue(userAgent.contains("ca_bundle/1.0"));
+    assertTrue(userAgent.contains("(ca_pinning=enabled)"));
+  }
+}


### PR DESCRIPTION
## Description
- Added `CA_BUNDLE_VERSION = "1.0"` constant in `Http.java`
- Modified the legacy constructor and `ClientBuilder.build()` to append `ca_bundle/1.0` and `(ca_pinning=enabled|disabled)` to the user agent string based on the `disableCaPinning` runtime state
- The pinning status is derived from the same `disableCaPinning` flag that configures TLS, so the reported value always matches the client's actual pinning state

## How Has This Been Tested?
- `testDefaultBuilder_includesCaBundleVersion` — verifies `ca_bundle/1.0` is present in the user agent
- `testDefaultBuilder_includesCaPinningEnabled` — verifies `(ca_pinning=enabled)` when pinning is not disabled
- `testDisableCaPinning_includesCaPinningDisabled` — verifies `(ca_pinning=disabled)` when `disableCaPinning()` is called
- `testLegacyConstructor_includesCaBundleAndPinningEnabled` — verifies both fields present via the deprecated constructor path

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)