### PR TITLE
chore: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -17,9 +17,9 @@ jobs:
         java: [8, 11, 17]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup java
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up JDK 11
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -25,13 +25,13 @@ jobs:
       uses: duosecurity/duo_client_python/.github/actions/sbom-convert@master
 
     - name: Archive SBOM artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: duo_client_java_sbom
         path: spdx.json
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions ahead of the runner change: GitHub Actions runners default to Node 24 on **2026-06-16** and remove Node 20 in **fall 2026**. JS actions on Node 12/16/20 are all affected.

Every JS-based action is bumped to its latest Node 24-capable release, **SHA-pinned** with a version comment.

## Not changed (no Node 24 release / composite / archived)
- `darenm/Setup-VSTest` — no Node 24 release exists
- `dtolnay/rust-toolchain` — composite action, unaffected
- `actions/create-release`, `actions/upload-release-asset` — archived; need a rewrite

Only present where applicable in this repo.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

*This PR was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)